### PR TITLE
Add support for document headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ Dumps all flag options applied to the caller. Either to the given `$file` path, 
 
 This function may be useful in figuring out if the Discount library you're linked to actually has the flags you need.
 
+### title
+
+    method title(Text::Markdown::Discount:D: --> Str)
+
+Returns the title parsed from the document header.
+
+### author
+
+    method author(Text::Markdown::Discount:D: --> Str)
+
+Returns the author parsed from the document header.
+
+### date
+
+    method date(Text::Markdown::Discount:D: --> Str)
+
+Returns the date parsed from the document header.
+
 Text::Markdown Compatibility
 ----------------------------
 

--- a/lib/Text/Markdown/Discount.pm6
+++ b/lib/Text/Markdown/Discount.pm6
@@ -100,6 +100,18 @@ class MMIOT is repr('CPointer')
     sub mkd_cleanup(MMIOT)
         is native('markdown') { * }
 
+    sub mkd_doc_title(MMIOT)
+        returns Str is encoded('utf8')
+        is native('markdown') { * }
+
+    sub mkd_doc_author(MMIOT)
+        returns Str is encoded('utf8')
+        is native('markdown') { * }
+
+    sub mkd_doc_date(MMIOT)
+        returns Str is encoded('utf8')
+        is native('markdown') { * }
+
 
     method from-str(Cool $str, int32 $flags --> MMIOT:D)
     {
@@ -114,6 +126,19 @@ class MMIOT is repr('CPointer')
         $fh.close;
         fail $! without $self;
         return $self;
+    }
+
+
+    method title(MMIOT:D: --> Str) {
+      return mkd_doc_title(self);
+    }
+
+    method author(MMIOT:D: --> Str) {
+      return mkd_doc_author(self);
+    }
+
+    method date(MMIOT:D: --> Str) {
+      return mkd_doc_date(self);
     }
 
 
@@ -243,6 +268,18 @@ method to-str(Text::Markdown::Discount:D: --> Str)
 method to-file(Text::Markdown::Discount:D: Str $file --> Bool)
 {
     return $!mmiot.html-to-file($file, $!flags);
+}
+
+method title(Text::Markdown::Discount:D: --> Str) {
+  return $!mmiot.title;
+}
+
+method author(Text::Markdown::Discount:D: --> Str) {
+  return $!mmiot.author;
+}
+
+method date(Text::Markdown::Discount:D: --> Str) {
+  return $!mmiot.date;
 }
 
 
@@ -389,6 +426,24 @@ path, or to the file descriptor C<$fd>. Defaults to dumping to file descriptor
 
 This function may be useful in figuring out if the Discount library you're
 linked to actually has the flags you need.
+
+=head3 title
+
+    method title(Text::Markdown::Discount:D: --> Str)
+
+Returns the title parsed from the document header.
+
+=head3 author
+
+    method author(Text::Markdown::Discount:D: --> Str)
+
+Returns the author parsed from the document header.
+
+=head3 date
+
+    method date(Text::Markdown::Discount:D: --> Str)
+
+Returns the date parsed from the document header.
 
 =head2 Text::Markdown Compatibility
 

--- a/t/06_meta.t
+++ b/t/06_meta.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+use lib "{$?FILE.IO.dirname}/data";
+use Text::Markdown::Discount;
+use TextMarkdownDiscountTestBoilerplate;
+
+{
+  my $result = Text::Markdown::Discount.from-str(q:to/END/);
+    % Delectus velit quo
+    % Crawford Mayert
+    % 2017-08-15T00:18:36.850Z
+    content
+    END
+
+  is $result.title, 'Delectus velit quo';
+  is $result.author, 'Crawford Mayert';
+  is $result.date, '2017-08-15T00:18:36.850Z';
+  is $result.to-str, '<p>content</p>';
+}
+
+done-testing


### PR DESCRIPTION
These are Pandoc-style document headers, e.g.

    % Title
    % Author
    % Date
    Document content