### PR TITLE
Remove DESTROY method

### DIFF
--- a/lib/Text/Markdown/Discount.pm6
+++ b/lib/Text/Markdown/Discount.pm6
@@ -167,12 +167,6 @@ class MMIOT is repr('CPointer') {
         mkd_flags_are($fh, $flags, 0);
         $fh.close;
     }
-
-
-    # FIXME Does this actually get called?
-    method DESTROY {
-        mkd_cleanup(self);
-    }
 }
 
 


### PR DESCRIPTION
It still leaks memory, but doesn't crash with double free anymore. Checked with README document for 100_000 iterations.